### PR TITLE
my-PV WiFi Meter now compatible for the my-PV Home Assistant integration  

### DIFF
--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -5,26 +5,41 @@
 #   mode: yaml
 
 views:
-  - title: my-PV Dashboard
-    path: view
+  - title: Home
     cards:
       - type: vertical-stack
         cards:
           - type: gauge
-            entity: sensor.ac_elwa_2_1_temperatur_1
-            severity:
-              green: 40
-              yellow: 50
-              red: 70
+            entity: sensor.ac_elwa_2_192_168_12_51_power1_solar
+            needle: false
           - type: history-graph
             entities:
-              - entity: sensor.ac_elwa_2_1_frequency
-              - entity: sensor.ac_elwa_2_1_temperatur_1
-            hours_to_show: 1
-          - show_name: true
-            show_icon: true
-            type: button
+              - entity: sensor.ac_elwa_2_192_168_12_51_temperatur_1
+          - type: entities
+            entities:
+              - entity: number.warmwassersicherstellung_1601502407030150
+          - type: button
             tap_action:
-              action: toggle   
-            entity: switch.ww1boost_switch
-            icon: mdi:water-boiler-auto
+              action: toggle
+            entity: button.save_warmwater_boost
+            name: Save Warmwater Boost
+            icon_height: 10px
+          - type: horizontal-stack
+            cards:
+              - type: button
+                tap_action:
+                  action: toggle
+                entity: switch.device_state
+                icon_height: 40px
+                name: Power
+                margin: 5px
+              - type: button
+                tap_action:
+                  action: toggle
+                entity: button.boost_button
+                icon_height: 40px
+                name: Boost
+          - type: entity
+            entity: sensor.ac_elwa_2_192_168_12_51_screen_mode
+            name: Status
+

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -3,6 +3,7 @@
 # Write this code to configuration.yaml:
 # lovelace:
 #   mode: yaml
+#choose your entities
 
 views:
   - title: Home


### PR DESCRIPTION
# Pull Request

## Description

Adding a my-PV WiFi Meter works now. You can choose your sensors and it can display them on your dashboard. Unlike the other devices, the WiFi Meter only has sensors, but no buttons, switches and sliders.

## Type of Change

Please check the type of change your PR is introducing:

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Other (please specify): __________

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include any relevant details such as test cases, scenarios, or steps.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify): __________

## Checklist

Please ensure the following before submitting your PR:

- [x] I have read and followed the [Contributing Guidelines](https://github.com/EldarKarahasanovic/myPVHomeAssistant/blob/main/CONTRIBUTING.md).
- [x] My code follows the project’s coding style and guidelines.
- [x] I have included appropriate tests for my changes.
- [x] My changes are backward compatible with the existing codebase.
- [x] I have tested my changes thoroughly and they are working as expected.

## Additional Information

Moreover,  the coordinator is completely async, performing aiohttp HTTP requests.

**Reviewer Notes:**

- Ensure that the PR meets the project’s contribution standards.
- Check for adherence to coding style and documentation requirements.
- Verify that all tests pass and are adequate.

Thank you for contributing to my-PV Home Assistant integration!

